### PR TITLE
BugFix: pay correctly to last player standing

### DIFF
--- a/__tests__/pot.test.js
+++ b/__tests__/pot.test.js
@@ -69,6 +69,7 @@ describe('Pot creation tests', () => {
         expect(table.pot.pots[0].amount).toEqual(600);
         expect(table.pot.pots[0].contributors).toEqual([0, 1, 2, 3, 5]);
     });
+
     test(`Check contents of side pot 1`, async () => {
         expect(table.pot.pots[1].amount).toEqual(400);
         expect(table.pot.pots[1].contributors).toEqual([1, 2, 3, 5]);
@@ -146,5 +147,44 @@ describe('Pot distribution tests', () => {
             .toMatch("D wins the pot (150)");
         expect(messages[2])
             .toMatch("E, F split the pot (200)");
+    });
+});
+
+
+describe('One person remaining tests', () => {
+    
+    const t = Utils.setupDefaultTable();
+    const table = t.table;
+    const act = Utils.act;
+
+    var positionE = 'E'.charCodeAt(0) - 'A'.charCodeAt(0);
+    table.seats[positionE].public.chipsInPlay = 40 + 164;
+
+    console.log("--------- Pre Flop -------------");
+    act(table, 'smallBlind', 'A', 'SmallBlind');
+    act(table, 'bigBlind', 'B', 'BigBlind');
+    act(table, 'preflop', 'C', 'Call');
+    act(table, 'preflop', 'D', 'Fold');
+    act(table, 'preflop', 'E', 'Raise', 40);
+    act(table, 'preflop', 'F', 'Fold');
+    act(table, 'preflop', 'A', 'Call');
+    act(table, 'preflop', 'B', 'Call');
+    act(table, 'preflop', 'C', 'Call');
+
+    // --------- Flop -------------
+    console.log("--------- Flop -------------");
+    act(table, 'flop', 'A', 'Check');
+    act(table, 'flop', 'B', 'Fold');
+    act(table, 'flop', 'C', 'Check');
+    // No D
+    act(table, 'flop', 'E', 'Bet', 164);
+    act(table, 'flop', 'A', 'Fold');
+    // No B
+    act(table, 'flop', 'C', 'Fold');
+
+    // --------- E should win -------------
+
+    test(`One person remaining`,  () => {
+        expect(table.seats[positionE].public.chipsInPlay).toEqual(40*4+164);
     });
 });

--- a/poker_modules/table.js
+++ b/poker_modules/table.js
@@ -482,7 +482,7 @@ Table.prototype.playerFolded = function() {
 	this.pot.removePlayer( this.public.activeSeat );
 	if( this.playersInHandCount <= 1 ) {
 		this.pot.addTableBets( this.seats );
-		var winnersSeat = this.findNextPlayer();
+        var winnersSeat = this.findNextPlayer(this.public.activeSeat, {'inHand': (x) => x} );
 		this.pot.giveToWinner( this.seats[winnersSeat] );
 		this.endRound();
 	} else {
@@ -593,7 +593,7 @@ Table.prototype.playerRaised = function( amount ) {
 		amount:amount
 	});
 
-	this.seats[this.public.activeSeat].raise( amount );
+	// this.seats[this.public.activeSeat].raise( amount );
 	var oldBiggestBet = this.public.biggestBet;
 	this.public.biggestBet = this.public.biggestBet < this.seats[this.public.activeSeat].public.bet ? this.seats[this.public.activeSeat].public.bet : this.public.biggestBet;
 	var raiseAmount = this.public.biggestBet - oldBiggestBet;


### PR DESCRIPTION
1. When one player raises and everybody else folds, the findNextPlayer was returning a wrong seat.
2. In playerRaised, the raise() function was called twice - resulting in a double raise
3. Added test to confirm